### PR TITLE
run lint-staged directly in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
         "lint": "eslint --fix --ext ts src/",
         "lint-check": "eslint --ext ts src/",
         "compile": "npx tsc -b ./",
-        "prepare": "husky install"
+        "prepare": "npx lint-staged"
     },
     "types": "lib/index.d.ts",
     "lint-staged": {


### PR DESCRIPTION
I think this should do it. The release runs npx oclif-dev pack, which implicitly calls the prepare script beforehand. Locally, this change got rid of the husky-related error that came w/ pack, but also allows husky to still be used for pre-commit hooks